### PR TITLE
Fix margins in message log

### DIFF
--- a/Lord Forte Backlog.rb
+++ b/Lord Forte Backlog.rb
@@ -181,7 +181,6 @@ class Window_MessageLog < Window_Base
     #self.active = false
      self.active = true
     self.openness = 0
-    self.padding *= 2
     @index = 0
     #create_animated_bg
     open
@@ -276,8 +275,7 @@ class Window_MessageLog < Window_Base
   #--------------------------------------------------------------------------
   def create_log_contents(size)
     self.contents.dispose
-   # self.contents = Bitmap.new(width - padding * 2, [height - padding * 2, size * line_height].max)
-   self.contents = Bitmap.new(width, [height - padding * 2, size * line_height].max)
+    self.contents = Bitmap.new(width - padding * 2, [height - padding * 2, size * line_height].max)
   end
   
   #--------------------------------------------------------------------------
@@ -345,7 +343,7 @@ class Window_MessageLog < Window_Base
       reset_font_settings
       text = convert_escape_characters(text)
       if Soulpour777::Animated_Log::Animated_Log[i][1] == true
-        pos = {:x => 96, :y => y, :new_x => 96, :height => calc_line_height(text)}
+        pos = {:x => 104, :y => y, :new_x => 104, :height => calc_line_height(text)}
         @right_margin = 0
       #process_character(text.slice!(0, 1), text, pos) until text.empty?
       @lastc = "\n"
@@ -354,7 +352,7 @@ class Window_MessageLog < Window_Base
           c = ' ' if c == "\n"
           if c =~ /[ \t]/
             c = '' if @lastc =~ /[\s\n\f]/
-            if pos[:x] + get_next_word_size(c, text) > contents.width - @right_margin - 96
+            if pos[:x] + get_next_word_size(c, text) > contents.width - @right_margin
               process_new_line(text, pos)
             else
               #process_normal_character(c, pos)
@@ -452,7 +450,7 @@ class Window_MessageLog < Window_Base
       reset_font_settings
       text = convert_escape_characters(text)
       if Soulpour777::Animated_Log::Animated_Log[i][1] == true
-        pos = {:x => 96, :y => y, :new_x => 96, :height => calc_line_height(text)}
+        pos = {:x => 104, :y => y, :new_x => 104, :height => calc_line_height(text)}
         @right_margin = 0
       #process_character(text.slice!(0, 1), text, pos) until text.empty?
 	  @lastc = "\n"
@@ -461,7 +459,7 @@ class Window_MessageLog < Window_Base
           #c = ' ' if c == "\n"
           if c =~ /[ \t]/
             c = '' if @lastc =~ /[\s\n\f]/
-            if pos[:x] + get_next_word_size(c, text) > contents.width - @right_margin - 96
+            if pos[:x] + get_next_word_size(c, text) > contents.width - @right_margin
               process_new_line(text, pos)
             else
               #process_normal_character(c, pos)


### PR DESCRIPTION
Issues fixed by this change:
* There's no gap between the face and the text
* Lines are wrapping earlier than they need to
* An unnecessary right-scroll icon is being displayed on the right-hand side of the box

Before fix:

![Screenshot 2024-09-22 14 08 03](https://github.com/user-attachments/assets/b45a08bc-f020-46d5-8780-2852bc9b0aaf)

After fix:

![Screenshot 2024-09-22 14 05 52](https://github.com/user-attachments/assets/04dbcc1b-9428-45cd-8c41-7b2bc8e329e1)

Test cases in normal text mode:

![Screenshot 2024-09-22 14 04 40](https://github.com/user-attachments/assets/442ea5a2-9fab-4fa8-880d-840764acf3ff)
![Screenshot 2024-09-22 14 04 50](https://github.com/user-attachments/assets/b3867a05-b545-48fa-b438-ad4b4946f159)
